### PR TITLE
Uses occam.Source to allow integration specs to run in parallel

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -28,22 +28,22 @@ func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
 
 	root, err := filepath.Abs("./..")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	thinBuildpack, err = dagger.PackageBuildpack(root)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	// HACK: we need to fix dagger and the package.sh scripts so that this isn't required
 	thinBuildpack = fmt.Sprintf("%s.tgz", thinBuildpack)
 
 	mriBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "mri")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	bundlerBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "bundler")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	bundleInstallBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "bundle-install")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	defer func() {
 		Expect(dagger.DeleteBuildpack(thinBuildpack)).To(Succeed())
@@ -54,7 +54,7 @@ func TestIntegration(t *testing.T) {
 
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
-	suite := spec.New("Integration", spec.Parallel(), spec.Report(report.Terminal{}))
+	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("SimpleApp", testSimpleApp)
 	suite("RackApp", testRackApp)
 	suite.Run(t)

--- a/integration/rack_app_test.go
+++ b/integration/rack_app_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +34,8 @@ func testRackApp(t *testing.T, context spec.G, it spec.S) {
 			image     occam.Image
 			container occam.Container
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -46,15 +48,19 @@ func testRackApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("creates a working OCI image with a thin start command", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "rack_app"))
+			Expect(err).NotTo(HaveOccurred())
+
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithBuildpacks(mriBuildpack, bundlerBuildpack, bundleInstallBuildpack, thinBuildpack).
 				WithNoPull().
-				Execute(name, filepath.Join("testdata", "rack_app"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
 			container, err = docker.Container.Run.
@@ -75,7 +81,7 @@ func testRackApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(content)).To(ContainSubstring("Hello world!"))
 
 			buildpackVersion, err := GetGitVersion()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("Thin Buildpack %s", buildpackVersion),


### PR DESCRIPTION
occam.Source duplicates the source code directory and makes it unique by adding a file with unique random content.